### PR TITLE
Add option to skip re-selecting row on updates

### DIFF
--- a/tablemutt.js
+++ b/tablemutt.js
@@ -388,7 +388,7 @@
         }
 
         // if former selected row is still on this page, ensure it's selected
-        if (this.rowKeyToIndex(oldSelectedRow) !== null && !this.options.skipRowreSelect) {
+        if (this.rowKeyToIndex(oldSelectedRow) !== null && !this.options.skipRowReselect) {
             this.selectRow(oldSelectedRow);
         }
     };


### PR DESCRIPTION
- Allows table updates without triggering row selection callbacks (for example, regenerating a side panel)
