### PR TITLE
Remove quo.js dependency

### DIFF
--- a/tablemutt.js
+++ b/tablemutt.js
@@ -556,10 +556,6 @@
                     self.prevPage();
                     return false;
                 });
-            $$('.panel').swipeRight(function() {
-                self.prevPage();
-                return false;
-            });
         } else {
             this.pagePrevious.classed("disabled", true);
         }
@@ -605,10 +601,6 @@
                     self.nextPage();
                     return false;
                 });
-            $$('.panel').swipeLeft(function() {
-                self.nextPage();
-                return false;
-            });
         } else {
             this.pageNext.classed("disabled", true);
         }


### PR DESCRIPTION
- Tablemutt was depending on quo.js to handle swipe events on
  the table. Now this dependency has been removed and it's no longer
  possible to swipe in order to navigate. The navigation buttons
  should be used instead.
