### PR TITLE
Use input text instead of search for textfilter input

### DIFF
--- a/tablemutt.js
+++ b/tablemutt.js
@@ -913,7 +913,7 @@
             .classed("tablemutt textfilter_container", true)
             .append("input")
             .classed("tablemutt textfilter", true)
-            .attr("type", "search")
+            .attr("type", "text")
             .attr("placeholder", this.options.filterbarPlaceholderText)
             .on("input", this.search_callback);
     };


### PR DESCRIPTION
Allow for cross browser css compatibility for input field.